### PR TITLE
New dockerfiles

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,20 +1,21 @@
 FROM ubuntu:xenial
 
 # Environment variables
-ENV NODE_VERSION=6.9.4
-ENV NPM_CONFIG_LOGLEVEL warn
-ENV DEBIAN_FRONTEND noninteractive
-ENV APP_USER=node
-ENV APP_USERGROUP=$APP_USER
-ENV HOME=/home/node
+ENV NODE_VERSION=6.9.4 \
+    NPM_CONFIG_LOGLEVEL=warn \
+    DEBIAN_FRONTEND=noninteractive \
+    APP_USER=node \
+    APP_USERGROUP=node
+
+WORKDIR /src
 
 # Add group and user for running the app
 RUN groupadd $APP_USERGROUP && \
-    useradd --create-home --home-dir $HOME -g $APP_USERGROUP $APP_USER
+    useradd --create-home --home-dir /src -g $APP_USERGROUP $APP_USER
 
 # Install general dependencies (based on nodesource/trusty-base)
 RUN apt-get update \
-  && apt-get install -y --no-install-recommends\
+  && apt-get install -y --no-install-recommends \
     apt-transport-https \
     ssh-client \
     build-essential \
@@ -28,88 +29,39 @@ RUN apt-get update \
     software-properties-common \
     zip unzip \
     wget \
-  && rm -rf /var/lib/apt/lists/*;
+    # Mapnik
+    libmapnik3.0 libmapnik-dev mapnik-utils \
+    gdal-bin \
+    libpango1.0-dev \
+    # Install PostGIS (needed to enable raster2pgsql at command line)
+    postgis \
+  # Clear apt lists
+  && rm -rf /tmp/* /var/lib/apt/lists/*
 
 # Install GOSU for stepping down from root
 ENV GOSU_VERSION 1.7
 RUN set -x \
-	&& wget -O /usr/local/bin/gosu "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$(dpkg --print-architecture)" \
-	&& wget -O /usr/local/bin/gosu.asc "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$(dpkg --print-architecture).asc" \
-	&& export GNUPGHOME="$(mktemp -d)" \
-	&& gpg --keyserver ha.pool.sks-keyservers.net --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4 \
-	&& gpg --batch --verify /usr/local/bin/gosu.asc /usr/local/bin/gosu \
-	&& rm -r "$GNUPGHOME" /usr/local/bin/gosu.asc \
-	&& chmod +x /usr/local/bin/gosu \
-	&& gosu nobody true
-
+  && wget -O /usr/local/bin/gosu "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$(dpkg --print-architecture)" \
+  && wget -O /usr/local/bin/gosu.asc "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$(dpkg --print-architecture).asc" \
+  && export GNUPGHOME="$(mktemp -d)" \
+  && gpg --keyserver ha.pool.sks-keyservers.net --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4 \
+  && gpg --batch --verify /usr/local/bin/gosu.asc /usr/local/bin/gosu \
+  && rm -r "$GNUPGHOME" /usr/local/bin/gosu.asc \
+  && chmod +x /usr/local/bin/gosu \
+  && gosu nobody true
 
 # Install Node.js from Nodesource
 RUN wget https://deb.nodesource.com/node_6.x/pool/main/n/nodejs/nodejs_$NODE_VERSION-1nodesource1~trusty1_amd64.deb -O node.deb \
   && dpkg -i node.deb \
   && rm node.deb
 
-# Mapnik dependencies
-RUN apt-get update \
-  && apt-get install -y --no-install-recommends \
-    libicu-dev \
-    libtiff5-dev \
-    libfreetype6-dev \
-    libpng12-dev \
-    libxml2-dev \
-    libproj-dev \
-    libsqlite3-dev \
-    libgdal-dev \
-    libcairo-dev \
-    python-cairo-dev \
-    postgresql-contrib \
-    libharfbuzz-dev \
-  && rm -rf /var/lib/apt/lists/*;
-
-# Install Boost
-RUN apt-get update \
-  && apt-get install -y --no-install-recommends \
-   libboost-dev \
-   libboost-filesystem-dev \
-   libboost-program-options-dev \
-   libboost-python-dev \
-   libboost-regex-dev \
-   libboost-system-dev \
-   libboost-thread-dev \
- && rm -rf /var/lib/apt/lists/*;
-
-# Build Mapnik
-RUN mkdir -p /tmp \
-  && wget -qO - https://github.com/mapnik/mapnik/releases/download/v3.0.13/mapnik-v3.0.13.tar.bz2 | tar -xj -C /tmp/ \
-  && cd /tmp/mapnik-v3.0.13 \
-  && python scons/scons.py configure JOBS=4 \
-  && make && make install JOBS=4 \
-  && rm -rf /tmp/mapnik-v3.0.13
-
-# Install Windshaft dependencies (Mapnik 3.0 and others)
-RUN apt-get update \
-    && apt-get install -y --no-install-recommends \
-      gdal-bin \
-      libpango1.0-dev \
-    && rm -rf /var/lib/apt/lists/*;
-
-# Install PostGIS (needed to enable raster2pgsql at command line)
-RUN apt-get update \
-  && apt-get install -y --no-install-recommends\
-    postgis \
-  && rm -rf /var/lib/apt/lists/*;
-
-# Copy config files and assign app directory permissions
-WORKDIR $HOME/domegis
-COPY . $HOME/domegis/
-
-# Fix permissings to user's .npm folder
-RUN chown -R $APP_USER:$APP_USERGROUP $HOME
+# Copy files
+COPY . /src
 
 # Install global npm dependencies and app
 RUN npm install -g node-gyp pg sequelize sequelize-cli nodemon bower \
-    && chown -R $APP_USER:$APP_USER $HOME/domegis \
-    && gosu $APP_USER:$APP_USER npm install \
-    && gosu $APP_USER:$APP_USER bower install -F
+    && npm install \
+    && bower install -F --allow-root
 
 # Patch entrypoint
 COPY entrypoint.sh /entrypoint.sh
@@ -117,4 +69,4 @@ RUN chmod +x /entrypoint.sh
 ENTRYPOINT ["/entrypoint.sh"]
 
 # Run node server
-CMD ["node", "src/ "]
+CMD ["node", "src/"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,8 +2,6 @@ version: '2'
 services:
   postgres:
     build: ./docker/postgres
-    volumes:
-      - ./data/postgres:/var/lib/postgresql/data
     ports:
       - 15432:5432
     environment:
@@ -23,6 +21,6 @@ services:
     environment:
       NODE_ENV: development
     volumes:
-      - .:/home/node/domegis
-      - /home/node/domegis/node_modules
-      - /home/node/domegis/bower_components
+      - .:/src
+      - /src/node_modules
+      - /src/bower_components

--- a/docker/postgres/Dockerfile
+++ b/docker/postgres/Dockerfile
@@ -16,11 +16,7 @@ RUN apt-get update \
     python-all \
     rlwrap \
     software-properties-common \
-  && rm -rf /var/lib/apt/lists/*;
-
-# Install postgresql-server-dev
-RUN apt-get update \
-  && apt-get install -y --no-install-recommends\
+    # Install postgresql-server-dev
     postgresql-server-dev-9.6 \
   && rm -rf /var/lib/apt/lists/*;
 
@@ -28,19 +24,17 @@ RUN apt-get update \
 RUN mkdir -p /tmp && cd /tmp \
   && apt-get update \
   && apt-get download postgresql-plpython-9.6=9.6.3-1.pgdg80+1 \
-  && dpkg --force-all -i ./postgresql-plpython-9.6_9.6.3-1.pgdg80+1_amd64.deb \
-  && rm -rf /tmp
+  && dpkg --force-all -i ./postgresql-plpython-9.6_9.6.3-1.pgdg80+1_amd64.deb
 
 # Install pg_schema_triggers extension
 RUN mkdir -p /tmp && cd /tmp \
   && git clone https://github.com/CartoDB/pg_schema_triggers.git \
   && cd pg_schema_triggers \
-  && make && make install \
-  && rm -rf /tmp
+  && make && make install
 
 # Install cartodb-postgresql extension
 RUN mkdir -p /tmp && cd /tmp \
-  &&  git clone https://github.com/CartoDB/cartodb-postgresql.git \
+  && git clone https://github.com/CartoDB/cartodb-postgresql.git \
   && cd cartodb-postgresql \
   && make all install \
   && rm -rf /tmp

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,11 +1,14 @@
 #!/bin/bash
 set -e
 
+echo "Updating permissions..."
+chown -R $APP_USER:$APP_USER /src
+
 # wait for postgres to accept connections
-sleep 30
+sleep 10
 until sequelize db:migrate; do
   >&2 echo "Postgres is unavailable - sleeping"
-  sleep 30
+  sleep 5
 done
 
 # allow the container to be started with `--user`


### PR DESCRIPTION
 - avoid removing apt lists and reupdate (unify apt installs)
 - chown on entrypoint
 - shrink env into 1 layer
 - put domegis files on `/src` directory
 - dont compile mapnik fomr source (using v3.0.9 from ubuntu rep and let it handle its deps)

Reduced docker hub building time from over 2 hours to 18 minutes and 80mb less size (compressed)